### PR TITLE
OPS-1143 make consul run as consul user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ spec/fixtures
 .rspec_system
 Gemfile.lock
 log/
+.idea
+*.iml

--- a/templates/consul.upstart.erb
+++ b/templates/consul.upstart.erb
@@ -25,7 +25,7 @@ script
     [ -e $DEFAULTS ] && . $DEFAULTS
 
     export GOMAXPROCS=${GOMAXPROCS:-2}
-    exec start-stop-daemon -u $USER -g $GROUP -p $PID_FILE -x $CONSUL -S -- agent -config-dir $CONFIG -pid-file $PID_FILE <%= scope.lookupvar('consul::extra_options') %>
+    exec start-stop-daemon -c $USER:$GROUP -u $USER -g $GROUP -p $PID_FILE -x $CONSUL -S -- agent -config-dir $CONFIG -pid-file $PID_FILE <%= scope.lookupvar('consul::extra_options') %>
 end script
 
 pre-stop script


### PR DESCRIPTION
This is a needed change for the module to actually do upstart as custom user correctly.

Although not a strong dependency on this, it is used in relation to: https://github.com/Tradeshift/tradeshift-puppet/pull/697

@JesperTerkelsen @tnn @sorenmat @callebjorkell @diogokiss 