### PR TITLE
Wait for service to come up

### DIFF
--- a/manifests/reload_service.pp
+++ b/manifests/reload_service.pp
@@ -12,7 +12,7 @@ class consul::reload_service {
   if $consul::manage_service == true and $consul::service_ensure == 'running' {
     exec { 'reload consul service':
       path        => [$consul::bin_dir,'/bin','/usr/bin'],
-      command     => "consul reload -rpc-addr=${consul::rpc_addr}:${consul::rpc_port}",
+      command     => "sleep 10; consul reload -rpc-addr=${consul::rpc_addr}:${consul::rpc_port}",
       refreshonly => true,
     }
   }


### PR DESCRIPTION
Triggering a set of refreshes for Service[consul] on an initial puppet
run will trigger the service to started/restarted but the service mgnt
will return faster then Consul is ready to listen on it's RPC interface,
therefore we have to wait for the consul agent to ready for RPC calls.

@JesperTerkelsen 